### PR TITLE
Remove redundant paragraph text from library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -3,6 +3,6 @@ version=1.0
 author=Blake Felt
 maintainer=Blake Felt
 sentence=Control of the TI ADS1262 and ADS1263.
-paragraph=Control of the TI ADS1262 and ADS1263.
+paragraph=
 url=
 category=Device Control


### PR DESCRIPTION
The Arduino IDE's Library Manager displays the text defined in the library.properties paragraph field immediately after the sentence text so it's not desirable to duplicate the sentence text in paragraph.